### PR TITLE
Add option to ignore console input and not send it to the serial port (IDFGH-10823)

### DIFF
--- a/esp_idf_monitor/base/argument_parser.py
+++ b/esp_idf_monitor/base/argument_parser.py
@@ -25,6 +25,12 @@ def get_parser():  # type: () -> argparse.ArgumentParser
     )
 
     parser.add_argument(
+        '--ignore-input',
+        help='Do not send console input to the serial port',
+        action='store_true'
+    )
+
+    parser.add_argument(
         '--disable-address-decoding', '-d',
         help="Don't print lines about decoded addresses from the application ELF file",
         action='store_true',

--- a/esp_idf_monitor/idf_monitor.py
+++ b/esp_idf_monitor/idf_monitor.py
@@ -86,6 +86,7 @@ class Monitor:
         make='make',  # type: str
         encrypted=False,  # type: bool
         reset=True,  # type: bool
+        ignore_input=False,  # type: bool
         toolchain_prefix=DEFAULT_TOOLCHAIN_PREFIX,  # type: str
         eol='CRLF',  # type: str
         decode_coredumps=COREDUMP_DECODE_INFO,  # type: str
@@ -105,6 +106,7 @@ class Monitor:
         sys.stderr = get_ansi_converter(sys.stderr, force_color=force_color)  # type: ignore
         self.console.output = get_ansi_converter(self.console.output, force_color=force_color)
         self.console.byte_output = get_ansi_converter(self.console.byte_output, force_color=force_color)
+        self.ignore_input = ignore_input
 
         self.elf_file = elf_file or ''
         self.elf_exists = os.path.exists(self.elf_file)
@@ -214,7 +216,8 @@ class Monitor:
             self.serial_handler.handle_commands(data, self.target, self.run_make, self.console_reader,
                                                 self.serial_reader)
         elif event_tag == TAG_KEY:
-            self.serial_write(codecs.encode(data))
+            if not self.ignore_input:
+                self.serial_write(codecs.encode(data))
         elif event_tag == TAG_SERIAL:
             self.serial_handler.handle_serial_input(data, self.console_parser, self.coredump,  # type: ignore
                                                     self.gdb_helper, self._line_matcher,
@@ -367,6 +370,7 @@ def main() -> None:
                       args.make,
                       args.encrypted,
                       not args.no_reset,
+                      args.ignore_input,
                       args.toolchain_prefix,
                       args.eol,
                       args.decode_coredumps,


### PR DESCRIPTION
Useful for applications that never read the serial port, or may react in undesirable ways to input on the serial port when using the monitor.

This can be used to prevent accidental serial port writes or as a workaround for serial writes hanging (#3).