### PR TITLE
Handle OSError when using termios.TIOCGSERIAL (IDFGH-11054)

### DIFF
--- a/esp_idf_monitor/base/serial_reader.py
+++ b/esp_idf_monitor/base/serial_reader.py
@@ -132,7 +132,7 @@ class SerialReader(Reader):
         buf = struct.pack(struct_format, *serial_struct)
         try:
             fcntl.ioctl(self.serial.fd, termios.TIOCSSERIAL, buf)
-        except PermissionError:
+        except OSError:
             # Discard written but not yet transmitted data
             termios.tcflush(self.serial.fd, termios.TCOFLUSH)
 


### PR DESCRIPTION
The serial port may not always support the TIOCGSERIAL ioctl, e.g. the ESP32-C6-DevKitC-1 UART:

```
  File "esp_idf_monitor/base/serial_reader.py", line 119, in _disable_closing_wait_or_discard_data
    buf = fcntl.ioctl(self.serial.fd, termios.TIOCGSERIAL, buf)
OSError: [Errno 25] Inappropriate ioctl for device
```

Handle OSError the same way as PermissionError (which is a subclass).