### PR TITLE
feat(esp-idf-monitor): Add --retry-open flag  (IDFGH-13270)

### DIFF
--- a/esp_idf_monitor/base/argument_parser.py
+++ b/esp_idf_monitor/base/argument_parser.py
@@ -139,4 +139,10 @@ def get_parser():  # type: () -> argparse.ArgumentParser
         default=False,
         action='store_true')
 
+    parser.add_argument(
+        '--retry-open',
+        help='Indefinitely retry opening the port device for the first time',
+        default=False,
+        action='store_true')
+
     return parser

--- a/esp_idf_monitor/base/constants.py
+++ b/esp_idf_monitor/base/constants.py
@@ -55,7 +55,7 @@ GDB_EXIT_TIMEOUT = 0.3  # time delay between exit and writing GDB_UART_CONTINUE_
 LAST_LINE_THREAD_INTERVAL = 0.1
 
 MINIMAL_EN_LOW_DELAY = 0.005
-RECONNECT_DELAY = 0.5  # timeout between reconnect tries
+RECONNECT_DELAY = 0.1  # timeout between reconnect tries
 CHECK_ALIVE_FLAG_TIMEOUT = 0.25  # timeout for checking alive flags (currently used by serial reader)
 
 # closing wait timeout for serial port

--- a/esp_idf_monitor/idf_monitor.py
+++ b/esp_idf_monitor/idf_monitor.py
@@ -90,6 +90,7 @@ class Monitor:
         make='make',  # type: str
         encrypted=False,  # type: bool
         reset=DEFAULT_TARGET_RESET,  # type: bool
+        retry_open=False,  # type: bool
         toolchain_prefix=DEFAULT_TOOLCHAIN_PREFIX,  # type: str
         eol='CRLF',  # type: str
         decode_coredumps=COREDUMP_DECODE_INFO,  # type: str
@@ -128,7 +129,7 @@ class Monitor:
             # testing hook: when running tests, input from console is ignored
             socket_test_mode = os.environ.get('ESP_IDF_MONITOR_TEST') == '1'
             self.serial = serial_instance
-            self.serial_reader = SerialReader(self.serial, self.event_queue, reset, target)  # type: Reader
+            self.serial_reader = SerialReader(self.serial, self.event_queue, reset, retry_open, target)  # type: Reader
 
             self.gdb_helper = GDBHelper(toolchain_prefix, websocket_client, self.elf_file, self.serial.port,
                                         self.serial.baudrate) if self.elf_exists else None
@@ -414,6 +415,7 @@ def main() -> None:
                       args.make,
                       args.encrypted,
                       not args.no_reset,
+                      args.retry_open,
                       args.toolchain_prefix,
                       args.eol,
                       args.decode_coredumps,


### PR DESCRIPTION
esp-idf-monitor frequently fails when trying to open the serial port of a device which deep-sleeps often.

e.g.:

```
# idf.py monitor -p /dev/cu.usbmodem6101 
--- esp-idf-monitor 1.4.0 on /dev/cu.usbmodem6101 115200 ---
--- Quit: Ctrl+] | Menu: Ctrl+T | Help: Ctrl+T followed by Ctrl+H ---
[Errno 2] could not open port /dev/cu.usbmodem6101: [Errno 2] No such file or directory: '/dev/cu.usbmodem6101'
Connection to /dev/cu.usbmodem6101 failed. Available ports:
/dev/cu.usbmodemF554393F21402
/dev/cu.AspergitosII
/dev/cu.Bluetooth-Incoming-Port
```

esp-idf-monitor currently already waits for the serial port _if_ it was opened successfully. This, however, doesn't help when opening the device for the first time.

This makes developers add [unnecessarily long sleeps](https://github.com/espressif/esp-idf/blob/9d41418bd25a08daf7b0b0bc95d864c11261777a/examples/system/ulp/lp_core/gpio/main/lp_core_gpio_example_main.c#L38) when the main CPU is awake, in order to give `esp-idf-monitor` the chance to find the serial port.

This PR adds a new flag `--retry-open` which retries opening the port indefinitely until the device shows up:

```
# idf.py monitor -p /dev/cu.usbmodem6101  --retry-open
--- esp-idf-monitor 1.4.0 on /dev/cu.usbmodem6101 115200 ---
--- Quit: Ctrl+] | Menu: Ctrl+T | Help: Ctrl+T followed by Ctrl+H ---
[Errno 2] could not open port /dev/cu.usbmodem6101: [Errno 2] No such file or directory: '/dev/cu.usbmodem6101'
Retrying to open port ......
ESP-ROM:esp32s3-20210327
rst:0x15 (USB_UART_CHIP_RESET),boot:0x8 (SPI_FAST_FLASH_BOOT)
Saved PC:0x4037b516
[...]
```