### PR TITLE
fix: Auto color for alternative timestamp formats (IDFGH-14376)

### DIFF
--- a/esp_idf_monitor/base/output_helpers.py
+++ b/esp_idf_monitor/base/output_helpers.py
@@ -17,7 +17,7 @@ ANSI_GREEN_B = ANSI_GREEN.encode()
 ANSI_YELLOW_B = ANSI_YELLOW.encode()
 ANSI_NORMAL_B = ANSI_NORMAL.encode()
 
-AUTO_COLOR_REGEX = re.compile(rb'^(I|W|E) \(\d+\)')
+AUTO_COLOR_REGEX = re.compile(rb'^(I|W|E) \([\d:\. -]+\)')
 
 COMMON_PREFIX = '---'
 


### PR DESCRIPTION
## Description

Fixes auto coloring for different timestamp formats (including future formats as per https://github.com/espressif/esp-idf/blob/master/components/log/Kconfig.format).

## Related

Introduced in https://github.com/espressif/esp-idf-monitor/commit/d49533f5331e3ad85f8ea7fbfa6ccb22a4fcab90

## Testing

![image](https://github.com/user-attachments/assets/7751d9be-754c-48c3-a8ce-81f2ff81371c)

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x] 🚨 This PR does not introduce breaking changes.
- [x] All CI checks (GH Actions) pass.
- [x] Documentation is updated as needed.
- [x] Tests are updated or added as necessary.
- [x] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.
