### PR TITLE
fix: Use absolute import in __main__ for pyinstaller/pyinstaller#2560 (IDFGH-14380)

### DIFF
--- a/esp_idf_monitor/__main__.py
+++ b/esp_idf_monitor/__main__.py
@@ -1,4 +1,4 @@
-from .idf_monitor import main
+from esp_idf_monitor.idf_monitor import main
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
## Description

Fix for pyinstaller/pyinstaller#2560

Allows PyInstaller binaries to be generated using:

```
pyinstaller --onefile --name esp-idf-monitor esp_idf_monitor/__main__.py
```

## Related

See also #20 

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x] 🚨 This PR does not introduce breaking changes.
- [x] All CI checks (GH Actions) pass.
- [x] Documentation is updated as needed.
- [x] Tests are updated or added as necessary.
- [x] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.
