### PR TITLE
fix: line matcher should account for system timestamps (IDFGH-14866)

### DIFF
--- a/esp_idf_monitor/base/line_matcher.py
+++ b/esp_idf_monitor/base/line_matcher.py
@@ -23,7 +23,7 @@ class LineMatcher(object):
     def __init__(self, print_filter):
         # type: (str) -> None
         self._dict = dict()
-        self._re = re.compile(r'^(?:\033\[[01];?[0-9]+m?)?([EWIDV]) \([0-9]+\) ([^:]+): ')
+        self._re = re.compile(r'^(?:\033\[[01];?[0-9]+m?)?([EWIDV]) (?:\([0-9]+\)|\([0-9]{2}:[0-9]{2}:[0-9]{2}\.[0-9]{3}\)) ([^:]+): ')
         items = print_filter.split()
         if len(items) == 0:
             self._dict['*'] = self.LEVEL_V  # default is to print everything


### PR DESCRIPTION
Otherwise it just wouldn't match for any lines that used system timestamps, so print filter wouldn't be functional.

<!--
- Read and understand the project style guidelines (`CONTRIBUTION.md`).
- For Work In Progress Pull Requests, please use the Draft PR feature. See https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
- For a timely review/response, please avoid force-pushing additional commits if your PR has already received reviews or comments.
- Include screenshots for any CLI or UI changes.
- Keep PRs as small as possible; large PRs are difficult to review.
-->

## Description
Closes #24 

> Add this regex to line matcher, it should work:
> ```
>         self._re = re.compile(r'^(?:\033\[[01];?[0-9]+m?)?([EWIDV]) (?:\([0-9]+\)|\([0-9]{2}:[0-9]{2}:[0-9]{2}\.[0-9]{3}\)) ([^:]+): ')
> ```

<!-- 
- If you want to insert images (screenshots, diagrams, etc.), please format them:
    Bad link to the image (not formatted):   ![image](https://github.com/user-attachments/assets/ad3383cd-8f38-4d06-9ecf-3305e299307d)~~
    Good link to the image (formatted):       <img src="https://github.com/user-attachments/assets/ad3383cd-8f38-4d06-9ecf-3305e299307d" width=500px>
-->

## Related

Conisder adding support for Log v2 format as suggested by https://github.com/espressif/esp-idf-monitor/issues/24#issuecomment-2728715862


## Testing

> Go to hello_world example and build it with CONFIG_LOG_TIMESTAMP_SOURCE_SYSTEM=y:
> ```
> cd examples/get-started/hello_world
> idf.py menuconfig
> idf.py flash monitor --print-filter "main_task:I"
> ```

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x] 🚨 This PR does not introduce breaking changes.
- [x] All CI checks (GH Actions) pass.
- [ ] Documentation is updated as needed.
- [ ] Tests are updated or added as necessary.
- [ ] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.
