### PR TITLE
add flag to save log monitor (IDFGH-17094)

### DIFF
--- a/esp_idf_monitor/base/argument_parser.py
+++ b/esp_idf_monitor/base/argument_parser.py
@@ -145,4 +145,11 @@ def get_parser():  # type: () -> argparse.ArgumentParser
         type=int,
     )
 
+    parser.add_argument(
+        '--save-log',
+        '-s',
+        help='Save log of monitor',
+        action='store_true',
+    )
+
     return parser

--- a/esp_idf_monitor/idf_monitor.py
+++ b/esp_idf_monitor/idf_monitor.py
@@ -514,11 +514,15 @@ def main() -> None:
             rom_elf_file,
         )
 
+        if args.save_log:
+            monitor.logger.start_logging()
+
         note_print(
             'Quit: {q} | Menu: {m} | Help: {m} followed by {h}'.format(
                 q=key_description(EXIT_KEY), m=key_description(MENU_KEY), h=key_description(CTRL_H)
             )
         )
+
         if args.print_filter != DEFAULT_PRINT_FILTER:
             msg = ''
             # Check if environment variable was used to set print_filter


### PR DESCRIPTION

## Description  
Add a new command-line option (`--save-log, '-s'`) to esp-idf-monitor to enable saving monitor output to a log file.

### Context
When debugging ESP-IDF applications, it is often necessary to save the serial monitor output for later analysis (e.g. crashes, boot logs, or long-running tests). 

This change adds native support for log file generation directly in esp-idf-monitor, improving usability and developer experience while keeping the existing workflow unchanged.

### Changes
- Added a new `--save-log` argument to the argument parse
- Add the option into the LinuxMonitor class  so logging starts automatically when enabled.

## Related
No related issues or PRs.

## Testing

- Tested the changes locally using a python virtual environment  with esp-idf-monitor changes installed.
- Ran `esp-idf-monitor`with the new `--save-log` option enabled.
- Verified that monitor output is correctly written to the log file.
- Confirmed that existing behavior is unchanged when the option is not used.

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [ x] 🚨 This PR does not introduce breaking changes.
- [ ] All CI checks (GH Actions) pass.
- [ x] Documentation is updated as needed.
- [ ] Tests are updated or added as necessary.
- [ ] Code is well-commented, especially in complex areas.
- [ x] Git history is clean — commits are squashed to the minimum necessary.
