### PR TITLE
Support custom_hard_reset_sequence in config (IDFGH-17261)

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Other advanced topics like configuration file will be described in the following
 - [Configuration File](#configuration-file)
   - [File Location](#file-location)
   - [Configuration Options](#configuration-options)
-    - [Custom Reset Sequence](#custom-reset-sequence)
+    - [Custom Reset Sequences](#custom-reset-sequences)
       - [Share Configuration Across Tools](#share-configuration-across-tools)
   - [Syntax](#syntax)
 - [Embedded Command Execution](#embedded-command-execution)
@@ -89,25 +89,26 @@ A different location for the configuration file can be specified with the `ESP_I
 
 Below is a table listing the available configuration options:
 
-| Option Name                | Description                                              | Default Value  |
-|----------------------------|----------------------------------------------------------|----------------|
-| `menu_key`                 | Key to access the main menu.                             | `T`            |
-| `exit_key`                 | Key to exit the monitor.                                 | `]`            |
-| `chip_reset_key`           | Key to initiate a chip reset.                            | `R`            |
-| `recompile_upload_key`     | Key to recompile and upload.                             | `F`            |
-| `recompile_upload_app_key` | Key to recompile and upload just the application.        | `A`            |
-| `toggle_output_key`        | Key to toggle the output display.                        | `Y`            |
-| `toggle_log_key`           | Key to toggle the logging feature.                       | `L`            |
-| `toggle_timestamp_key`     | Key to toggle timestamp display.                         | `I`            |
-| `chip_reset_bootloader_key`| Key to reset the chip to bootloader mode.                | `P`            |
-| `exit_menu_key`            | Key to exit the monitor from the menu.                   | `X`            |
-| `skip_menu_key`            | Pressing the menu key can be skipped for menu commands.  | `False`        |
-| `reconnect_delay`          | Delay between reconnect retries (in seconds)             | 0.5            |
-| `custom_reset_sequence`    | Custom reset sequence for resetting into the bootloader. | N/A            |
+| Option Name                  | Description                                              | Default Value  |
+|------------------------------|----------------------------------------------------------|----------------|
+| `menu_key`                   | Key to access the main menu.                             | `T`            |
+| `exit_key`                   | Key to exit the monitor.                                 | `]`            |
+| `chip_reset_key`             | Key to initiate a chip reset.                            | `R`            |
+| `recompile_upload_key`       | Key to recompile and upload.                             | `F`            |
+| `recompile_upload_app_key`   | Key to recompile and upload just the application.        | `A`            |
+| `toggle_output_key`          | Key to toggle the output display.                        | `Y`            |
+| `toggle_log_key`             | Key to toggle the logging feature.                       | `L`            |
+| `toggle_timestamp_key`       | Key to toggle timestamp display.                         | `I`            |
+| `chip_reset_bootloader_key`  | Key to reset the chip to bootloader mode.                | `P`            |
+| `exit_menu_key`              | Key to exit the monitor from the menu.                   | `X`            |
+| `skip_menu_key`              | Pressing the menu key can be skipped for menu commands.  | `False`        |
+| `reconnect_delay`            | Delay between reconnect retries (in seconds).            | 0.5            |
+| `custom_reset_sequence`      | Custom reset sequence for resetting into the bootloader. | N/A            |
+| `custom_hard_reset_sequence` | Custom reset sequence for hard resetting the chip.       | N/A            |
 
-#### Custom Reset Sequence
+#### Custom Reset Sequences
 
-For more advanced users or specific use cases, IDF Monitor supports the configuration of a custom reset sequence using [configuration file](#configuration-file). This is particularly useful in extreme edge cases where the default sequence may not suffice.
+For more advanced users or specific use cases, IDF Monitor supports the configuration of custom reset sequences using [configuration file](#configuration-file). This is particularly useful in extreme edge cases where the default sequence may not suffice.
 
 The sequence is defined with a string in the following format:
 
@@ -128,7 +129,7 @@ Example:
 custom_reset_sequence = U0,1|W0.1|D1|R0|W0.5|D0
 ```
 
-Refer to [custom reset sequence](https://docs.espressif.com/projects/esptool/en/latest/esptool/configuration-file.html#custom-reset-sequence) from Esptool documentation for further details. Please note that `custom_reset_sequence` is the only used value from the Esptool configuration, and others will be ignored in IDF Monitor.
+Refer to [custom reset sequence](https://docs.espressif.com/projects/esptool/en/latest/esptool/configuration-file.html#custom-reset-sequence) from Esptool documentation for further details. Please note that `custom_reset_sequence` and `custom_hard_reset_sequence` are the only used values from the Esptool configuration, and others will be ignored in IDF Monitor.
 
 ##### Share Configuration Across Tools
 
@@ -143,10 +144,11 @@ skip_menu_key = True
 
 [esptool]
 custom_reset_sequence = U0,1|W0.1|D1|R0|W0.5|D0
+custom_hard_reset_sequence = R1|W0.1|R0
 ```
 
 > [!NOTE]
-> When using the `custom_reset_sequence` parameter in both the `[esp-idf-monitor]` section and the `[esptool]` section, the configuration from the `[esp-idf-monitor]` section will take precedence in IDF Monitor. Any conflicting configuration in the `[esptool]` section will be ignored.
+> When using the `custom_reset_sequence` or `custom_hard_reset_sequence` parameter in both the `[esp-idf-monitor]` section and the `[esptool]` section, the configuration from the `[esp-idf-monitor]` section will take precedence in IDF Monitor. Any conflicting configuration in the `[esptool]` section will be ignored.
 >
 > This precedence rule also applies when the configuration is spread across multiple files. The global esp-idf-monitor configuration will take precedence over the local esptool configuration.
 

--- a/esp_idf_monitor/base/reset.py
+++ b/esp_idf_monitor/base/reset.py
@@ -46,22 +46,29 @@ class Reset:
 
     def _load_config(self) -> None:
         """Load configuration for custom reset sequence
-        Look for custom_reset_sequence in esp-idf-monitor config, if not found fallback to esptool config
+        Look for custom_reset_sequence and custom_hard_reset_sequence in esp-idf-monitor config,
+        if not found fallback to esptool config
         """
         custom_cfg = Config()
         custom_config, self.config_path = custom_cfg.load_configuration()
         # try to get the custom reset sequence from esp-idf-monitor
-        self.esptool_config = False
+        self.bootloader_reset_from_esptool = False
+        self.hard_reset_from_esptool = False
         self.custom_seq = custom_config['esp-idf-monitor'].get('custom_reset_sequence')
+        self.custom_hard_seq = custom_config['esp-idf-monitor'].get('custom_hard_reset_sequence')
         if self.config_path is None:
             # config for esp-idf-monitor was not found, looking for esptool configuration
             # this is required in case the config file doesn't contain esp-idf-monitor section at all
             custom_cfg = Config(config_name='esptool')
             custom_config, self.config_path = custom_cfg.load_configuration()
         if self.custom_seq is None and 'esptool' in custom_config.keys():
-            # get reset sequence from esptool section
+            # get bootloader reset sequence from esptool section
             self.custom_seq = custom_config['esptool'].get('custom_reset_sequence')
-            self.esptool_config = True
+            self.bootloader_reset_from_esptool = self.custom_seq is not None
+        if self.custom_hard_seq is None and 'esptool' in custom_config.keys():
+            # get hard reset sequence from esptool section
+            self.custom_hard_seq = custom_config['esptool'].get('custom_hard_reset_sequence')
+            self.hard_reset_from_esptool = self.custom_hard_seq is not None
 
     def _get_port_pid(self) -> Optional[int]:
         """Get port PID to differentiate between JTAG and UART reset sequences"""
@@ -98,28 +105,33 @@ class Reset:
             status &= ~TIOCM_RTS
         fcntl.ioctl(self.serial_instance.fileno(), TIOCMSET, struct.pack('I', status))
 
-    def _parse_string_to_seq(self, seq_str: str) -> str:
+    def _parse_string_to_seq(self, seq_str: str, option_name: str = 'custom_reset_sequence') -> str:
         """Parse custom reset sequence from a config"""
         try:
             cmds = seq_str.split('|')
             fn_calls_list = [self.format_dict[cmd[0]].format(cmd[1:]) for cmd in cmds]
         except Exception as e:
-            error_print(f'Invalid "custom_reset_sequence" option format: {e}')
+            error_print(f'Invalid "{option_name}" option format: {e}')
             return ''
         return '\n'.join(fn_calls_list)
 
     def hard(self) -> None:
         """Hard reset chip"""
-        self._setRTS(LOW)  # EN=LOW, chip in reset
-        time.sleep(self.chip_config['reset'])
-        self._setRTS(HIGH)  # EN=HIGH, chip out of reset
+        if self.custom_hard_seq:
+            source = 'esptool ' if self.hard_reset_from_esptool else ''
+            note_print(f'Using custom hard reset sequence from {source}config file: {self.config_path}')
+            exec(self._parse_string_to_seq(self.custom_hard_seq, 'custom_hard_reset_sequence'))
+        else:
+            self._setRTS(LOW)  # EN=LOW, chip in reset
+            time.sleep(self.chip_config['reset'])
+            self._setRTS(HIGH)  # EN=HIGH, chip out of reset
 
     def to_bootloader(self) -> None:
         """Reset chip into bootloader"""
         if self.custom_seq:
             # use custom reset sequence set in config file
-            source = 'from esptool ' if self.esptool_config else ''
-            note_print(f'Using custom reset sequence {source}config file: {self.config_path}')
+            source = 'esptool ' if self.bootloader_reset_from_esptool else ''
+            note_print(f'Using custom reset sequence from {source}config file: {self.config_path}')
             exec(self._parse_string_to_seq(self.custom_seq))
         elif self.port_pid == USB_JTAG_SERIAL_PID:
             # use reset sequence for JTAG

--- a/esp_idf_monitor/base/serial_reader.py
+++ b/esp_idf_monitor/base/serial_reader.py
@@ -108,9 +108,12 @@ class SerialReader(Reader):
 
         self.serial.open()
 
-        # set DTR/RTS into expected HIGH state, but set the RTS first to avoid reset
-        self.reset_strategy._setRTS(HIGH)
-        self.reset_strategy._setDTR(HIGH)
+        # When using custom hard reset, skip before reset so the sequence can control lines;
+        # when --no-reset is used, use the default behavior even if custom hard reset is set
+        if not self.reset_strategy.custom_hard_seq or not reset:
+            # set DTR/RTS into expected HIGH state, but set the RTS first to avoid reset
+            self.reset_strategy._setRTS(HIGH)
+            self.reset_strategy._setDTR(HIGH)
         if reset:
             self.reset_strategy.hard()
 

--- a/esp_idf_monitor/config.py
+++ b/esp_idf_monitor/config.py
@@ -22,6 +22,7 @@ VALID_OPTIONS = [
     'skip_menu_key',
     'reconnect_delay',
     'custom_reset_sequence',  # from esptool config
+    'custom_hard_reset_sequence',
 ]
 
 

--- a/test/host_test/test_monitor.py
+++ b/test/host_test/test_monitor.py
@@ -644,7 +644,7 @@ class TestConfig(TestBaseClass):
 
         with open(err) as f_err:
             stderr = f_err.read()
-        msg = f'--- Using custom reset sequence config file: {os.path.join(os.getcwd(), "config.cfg")}'
+        msg = f'--- Using custom reset sequence from config file: {os.path.join(os.getcwd(), "config.cfg")}'
         assert msg in stderr
         # remove everything before message about using custom config to remove starting reset sequence
         log_seq = stderr.split(msg)[1]
@@ -673,8 +673,33 @@ class TestConfig(TestBaseClass):
         with open(err) as f_err:
             stderr = f_err.read()
         # check for error message that reset sequence was invalid
-        assert f'--- Using custom reset sequence config file: {os.path.join(os.getcwd(), "config.cfg")}' in stderr
+        assert f'--- Using custom reset sequence from config file: {os.path.join(os.getcwd(), "config.cfg")}' in stderr
         assert '--- Error: Invalid "custom_reset_sequence" option format: \'F\'' in stderr
+
+    def test_custom_hard_reset_sequence(self):
+        """Use custom hard reset sequence"""
+        # create custom config with custom hard reset sequence
+        self.create_config({'custom_hard_reset_sequence': 'R1|W0.1|R0'})
+        # run monitor
+        _, err = self.run_monitor_async(args=['--no-reset'])
+        # hard reset chip
+        self.send_control('TR')
+        # wait for command to apply
+        time.sleep(0.5)
+        assert self.close_monitor_async() == 0
+        with open(err) as f_err:
+            stderr = f_err.read()
+        msg = f'--- Using custom hard reset sequence from config file: {os.path.join(os.getcwd(), "config.cfg")}'
+        assert msg in stderr
+        # remove everything before message about using custom config to remove starting reset sequence
+        log_seq = stderr.split(msg)[1]
+        # check in pyserial log that custom hard reset sequence was used (Note: we cannot test the wait part)
+        my_seq = [
+            'INFO:pySerial.socket:ignored _update_rts_state(1)',  # R1
+            'INFO:pySerial.socket:ignored _update_dtr_state(False)',  # expected workaround for windows RTS setting
+            'INFO:pySerial.socket:ignored _update_rts_state(0)',  # R0
+        ]
+        assert '\n'.join(my_seq) in log_seq
 
 
 class TestCStyleConversion(TestBaseClass):


### PR DESCRIPTION
## Description

`esptool` already supports `custom_hard_reset_sequence` in its config file, but `esp-idf-monitor` does not — `hard()` always toggles RTS regardless of config. This PR adds matching support to the monitor:

  1. Loads `custom_hard_reset_sequence` from `[esp-idf-monitor]` config section
  2. Uses it in `hard()` when available, falling back to the default RTS toggle
  3. Skips the post-open DTR/RTS toggle when a custom hard reset sequence is configured, to avoid interfering with custom pin assignments

This brings `esp-idf-monitor` in line with `esptool`'s existing custom reset sequence support.

## Related

Complements the `custom_reset_sequence` support already present in both `esptool` and `esp-idf-monitor`.

## Testing

Tested on an ESP32-S3 board with non-standard (swapped) DTR/RTS wiring using the following config:

```ini
[esp-idf-monitor]
custom_hard_reset_sequence = R0|D0|W0.1|R1|D1
```

Verified that idf.py monitor correctly resets the board on connect and via the reset key.