### PR TITLE
fix(binlog): Handle invalid formats gracefully with a warning rather than crashing (IDFGH-17522)

### DIFF
--- a/esp_idf_monitor/base/binlog.py
+++ b/esp_idf_monitor/base/binlog.py
@@ -462,7 +462,8 @@ class ArgFormatter(string.Formatter):
         elif specifier == 'p':
             return '#x'
         else:
-            raise ValueError(f'Unsupported format specifier: {specifier}')
+            warning_print(f'Unsupported format specifier: {specifier}. Treating as string.')
+            return 's'
 
     def c_format(self, fmt: str, args: Any) -> str:
         """Format a C-style string using Python's format method."""
@@ -472,16 +473,44 @@ class ArgFormatter(string.Formatter):
         while i_str < len(fmt):
             match = self.c_format_regex.search(fmt, i_str)
             if not match:
-                break
-            py_format = self.convert_to_pythonic_format(match)
-            if match.group(0) == '%%':
-                # Literal percent sign, no need to format
-                formatted_str = '%'
-            else:
-                formatted_str = self.format(py_format, args[i_arg] if args else None)  # This will call format_field()
+                # Check for unsupported format specifier: % followed by any char (not handled by regex)
+                percent_idx = fmt.find('%', i_str)
+                if percent_idx == -1 or percent_idx == len(fmt) - 1:
+                    # No more percent or percent at end
+                    break
+                next_char = fmt[percent_idx + 1]
+                if next_char == '%':
+                    # Literal percent, skip
+                    result_parts.append(fmt[i_str:percent_idx] + '%')
+                    i_str = percent_idx + 2
+                    continue
+                # Treat as unsupported specifier, substitute as string
+                warning_print(f'Unsupported format specifier: {next_char}. Treating as string.')
+                subst = str(args[i_arg]) if args and i_arg < len(args) else ''
+                result_parts.append(fmt[i_str:percent_idx] + subst)
                 i_arg += 1
-            result_parts.append(fmt[i_str : match.start()] + formatted_str)
-            i_str = match.end()
+                i_str = percent_idx + 2
+                continue
+            try:
+                py_format = self.convert_to_pythonic_format(match)
+                if match.group(0) == '%%':
+                    # Literal percent sign, no need to format
+                    formatted_str = '%'
+                else:
+                    formatted_str = self.format(
+                        py_format, args[i_arg] if args else None
+                    )  # This will call format_field()
+                    i_arg += 1
+                result_parts.append(fmt[i_str : match.start()] + formatted_str)
+                i_str = match.end()
+            except Exception as e:
+                # If any error occurs during formatting, include the original format specifier in the output
+                warning_print(
+                    f'Error formatting argument {i_arg} with format "{match.group(0)}":'
+                    + f' {e}. Including original format in output.'
+                )
+                result_parts.append(fmt[i_str : match.end()])
+                i_str = match.end()
         # Add remaining part of the string after last match
         result_parts.append(fmt[i_str:])
         return ''.join(result_parts)

--- a/test/host_test/test_monitor.py
+++ b/test/host_test/test_monitor.py
@@ -760,6 +760,22 @@ class TestCStyleConversion(TestBaseClass):
         formatted_output = formatter.c_format(c_fmt, [arg])
         assert formatted_output == output, f"Expected '{output}', got '{formatted_output}'"
 
+    @pytest.mark.parametrize(
+        'c_fmt, args, expected_output',
+        [
+            # Case: unsupported format specifier (should warn and treat as string)
+            ('|%z|', ['test'], '|test|'),
+            # Case: literal percent sign (should output '%')
+            ('Value: %%', [], 'Value: %'),
+        ],
+    )
+    def test_c_format_edge_cases(self, c_fmt, args, expected_output):
+        from esp_idf_monitor.base.binlog import ArgFormatter
+
+        formatter = ArgFormatter()
+        output = formatter.c_format(c_fmt, args)
+        assert output == expected_output
+
 
 class TestEmbeddedMonitorCommands:
     """Tests for SecureMonitorCommandExecutor handling embedded monitor commands."""


### PR DESCRIPTION
## Description

Sometimes applications are not well behaved and include invalid format strings, or perhaps ones that esp-idf-monitor does not support. Existing behavior was to crash with an error message, this fix handles the invalid format as best we can without failing hard.

## Testing

Tested on my codebase for the last month or two, unit test included.
---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x] 🚨 This PR does not introduce breaking changes.
- [x] All CI checks (GH Actions) pass.
- [x] Documentation is updated as needed.
- [x] Tests are updated or added as necessary.
- [x] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.
