### PR TITLE
fix(console_reader): enable raw VT input on win32 (IDFGH-17962)

### DIFF
--- a/esp_idf_monitor/base/console_reader.py
+++ b/esp_idf_monitor/base/console_reader.py
@@ -35,9 +35,20 @@ class ConsoleReader(StoppableThread):
             # results in Critical Error in Windows: https://github.com/espressif/esp-idf/issues/12162
             # Note: UTF-8 characters seem to work even without this setting
             import ctypes
+            from ctypes import wintypes
 
             ctypes.windll.kernel32.SetConsoleOutputCP(console._saved_ocp)
             ctypes.windll.kernel32.SetConsoleCP(console._saved_icp)
+
+            # Enable ENABLE_VIRTUAL_TERMINAL_INPUT (0x0200) to allow raw escape sequences (like CPR)
+            # to pass to stdin without being mangled by ConPTY/conhost
+            self._stdin_handle = ctypes.windll.kernel32.GetStdHandle(-10)  # -10 = STD_INPUT_HANDLE
+            self._saved_in_mode = wintypes.DWORD()
+            if ctypes.windll.kernel32.GetConsoleMode(self._stdin_handle, ctypes.byref(self._saved_in_mode)):
+                ENABLE_VIRTUAL_TERMINAL_INPUT = 0x0200
+                ctypes.windll.kernel32.SetConsoleMode(
+                    self._stdin_handle, self._saved_in_mode.value | ENABLE_VIRTUAL_TERMINAL_INPUT
+                )
 
     def run(self):
         # type: () -> None
@@ -63,7 +74,7 @@ class ConsoleReader(StoppableThread):
                         import msvcrt
 
                         while not msvcrt.kbhit() and self.alive:  # type: ignore
-                            time.sleep(0.1)
+                            time.sleep(0.01)
                         if not self.alive:
                             break
                     c = self.console.getkey()
@@ -96,4 +107,8 @@ class ConsoleReader(StoppableThread):
                             self.event_queue.put(ret)
 
         finally:
+            if sys.platform == 'win32' and hasattr(self, '_saved_in_mode'):
+                import ctypes
+
+                ctypes.windll.kernel32.SetConsoleMode(self._stdin_handle, self._saved_in_mode)
             self.console.cleanup()


### PR DESCRIPTION
Some brief context: I've been working on an [asynchronous version of the ESP-IDF Console component](https://github.com/jwidess/esp-async-console) for sometime, however I've been plagued by issues with the ESP-IDF Monitor terminal that I haven't had with other terminals like Tera Term or WindTerm. Primarily, my issues revolved around trying to probe the ESP-IDF Monitor for its size with a Cursor Position Request (CPR) sequence, which did not work properly and left garbage data in the prompt after timing out of a `getColumns` function.


## Summary:

Enabled `ENABLE_VIRTUAL_TERMINAL_INPUT` (0x0200) on the stdin handle on Windows to prevent ConPTY/conhost from translating CPR and other ANSI escape sequences into virtual F3 keys. Saves the original console input mode and restores on exit in ConsoleReader's finally block to prevent mode leakage. Also reduced win32 kbhit() sleep polling interval from 100ms to 10ms to reduce latency when forwarding escape sequences back to the serial device. This cut latency in half in my tests, anything faster has diminishing returns.


## Description

This fixes a bug on Windows where Cursor Position Reports (CPR, `ESC[6n`) sequences, and other ANSI escape sequences, sent from the monitor are mangled into garbage keystrokes and sent to the target device. It also cuts the delay of these exchanges in ~half.

### Core Issue
1.  **ConPTY/conhost Mangling:** By default, standard input does not have `ENABLE_VIRTUAL_TERMINAL_INPUT` (`0x0200`) enabled on Windows. When the host terminal responds to a query (like `\x1b[6n`) by sending the coordinates back (`ESC [ <r> ; <c> R`), Windows ConPTY fails to parse it as raw text. Because the sequence starts with `ESC` and ends with `R` (which resembles legacy VT100 shortcut for F3, `ESC O R`), I am assuming conhost translates the entire CPR response into a single **F3 key event** (`0x00` + `'='`).
2.  **`pyserial` Key-Mapping Typo:** When `pyserial`'s `miniterm.Console` processes the F3 event, it maps it back to a VT100 string using its `fncodes` dictionary. But due to a typo in `pyserial` (`\1b` in octal instead of `\x1b` or `\033`), F3 gets mapped to the literal string `\x01bOR` (`0x01` + `'b'` + `'O'` + `'R'`). 
    - This typo was fixed in pyserial with commit [8813fb5](https://github.com/pyserial/pyserial/commit/8813fb57ac2b51808b424323344305fdca286b23).
    - However, the latest stable release of pyserial (v3.5) still contains this issue: [miniterm.py#L106 (v3.5)](https://github.com/pyserial/pyserial/blob/v3.5/serial/tools/miniterm.py#L106).
    - The fix is present on the pyserial master branch: [miniterm.py#L107 (master)](https://github.com/pyserial/pyserial/blob/a5c48d445fbc1943d4fabf8d9090a50fda3172fd/serial/tools/miniterm.py#L107).
3.  **Prompt Garbage:** This mangled string is forwarded to the target device, leading to a, in my case, timeout of `getColumns` followed by `bOR` text ending up on my console prompt.
4.  **Forwarding Delay:** The Windows implementation of `ConsoleReader` polls `msvcrt.kbhit()` and sleeps for `100ms` if no keys are in the buffer. This would result in ~200-300ms of delay. Reducing this to 10ms got this down to 140-160ms; however, I haven't figured out why this delay is still so long, but at least this is an improvement. 


### Solutions
1.  **Enable Raw VT Input:** In `ConsoleReader.__init__`, we enable `ENABLE_VIRTUAL_TERMINAL_INPUT (0x0200)` on the stdin handle. Thus, ConPTY bypasses key translation and passes all ANSI/VT100 escape sequences through standard input as raw chars.
2.  **Clean-Up:** Save the original console input mode and restore it in the `finally` block of `ConsoleReader.run()` to prevent leaking states when the monitor is closed.
3.  **Faster Polling:** Reduced the `kbhit()` polling sleep from `100ms` to `10ms`.


## Related

I've found the following relevant commits below that have worked on escape sequences:
*   **Commit `6da761b`:** Fixed the *output* path, modifying `ANSIColorConverter` so it does not intercept or mangle cursor position and status escape sequences written from the target device to the host terminal.
*   **Commit `c4d6095`:** Added flushing for `CONSOLE_STATUS_QUERY` (`\x1b[5n`) to ensure status queries reach the terminal emulator immediately.

However, the **input** side of console reading wasn't configured, causing all responses from the terminal to the target device to fail on Windows.


## Testing

*   **Before Patch:** CPR sequences didn't work and my e.g. `getColumns` func timed out, followed by `bOR` appearing on the prompt.
*   **After Patch:** Stdin escape sequences (including CPR) pass through raw and unmangled. 
*   **Latency Drop:** Devices can now successfully get coordinates on Windows in **~140-160ms** without prompt garbage.

<!--
- Explain how you tested your change or new feature.
- If you tested changes in a clean environment (Docker container, new virtualenv, fresh Virtual Machine), state it here.
-->

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x] 🚨 This PR does not introduce breaking changes.
- [ ] All CI checks (GH Actions) pass.
- [x] Documentation is updated as needed.
- [x] Tests are updated or added as necessary.
- [x] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.
