### PR TITLE
feat: Add runtime toggle for address decoding (IDFGH-18264)

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ printf 'reset\nexpect ALL TESTS PASSED\n' | idf-monitor /dev/ttyUSB0
 | `output` | Toggle printing of the serial output |
 | `log` | Toggle saving the output into a file |
 | `timestamps` | Toggle prepending timestamps to the output |
+| `addresses` | Toggle decoding of addresses in the output into source locations |
 | `bootloader` | Reset the chip into the download (bootloader) mode |
 | `exit` | Quit the monitor; pending serial output is drained first |
 
@@ -176,6 +177,7 @@ Below is a table listing the available configuration options:
 | `toggle_output_key`          | Key to toggle the output display.                          | `Y`            |
 | `toggle_log_key`             | Key to toggle the logging feature.                         | `L`            |
 | `toggle_timestamp_key`       | Key to toggle timestamp display.                           | `I`            |
+| `toggle_address_decoding_key` | Key to toggle decoding of addresses.                      | `D`            |
 | `chip_reset_bootloader_key`  | Key to reset the chip to bootloader mode.                  | `P`            |
 | `exit_menu_key`              | Key to exit the monitor from the menu.                     | `X`            |
 | `skip_menu_key`              | Pressing the menu key can be skipped for menu commands.    | `False`        |
@@ -245,6 +247,7 @@ recompile_upload_all_key = E
 toggle_output_key = Y
 toggle_log_key = L
 toggle_timestamp_key = I
+toggle_address_decoding_key = D
 chip_reset_bootloader_key = P
 exit_menu_key = X
 skip_menu_key = False

--- a/esp_idf_monitor/base/command_reader.py
+++ b/esp_idf_monitor/base/command_reader.py
@@ -21,6 +21,7 @@ from .constants import CMD_MAKE
 from .constants import CMD_OUTPUT_TOGGLE
 from .constants import CMD_RESET
 from .constants import CMD_STOP
+from .constants import CMD_TOGGLE_ADDRESS_DECODING
 from .constants import CMD_TOGGLE_LOGGING
 from .constants import CMD_TOGGLE_TIMESTAMPS
 from .constants import EXIT_EXPECT_TIMEOUT
@@ -81,6 +82,7 @@ class CommandReader(StoppableThread):
         'output': CMD_OUTPUT_TOGGLE,  # toggle output display
         'log': CMD_TOGGLE_LOGGING,  # toggle logging to file
         'timestamps': CMD_TOGGLE_TIMESTAMPS,  # toggle timestamps
+        'addresses': CMD_TOGGLE_ADDRESS_DECODING,  # toggle decoding of addresses
         'bootloader': CMD_ENTER_BOOT,  # reset the chip into bootloader
     }
 

--- a/esp_idf_monitor/base/console_parser.py
+++ b/esp_idf_monitor/base/console_parser.py
@@ -19,6 +19,7 @@ from .constants import CMD_MAKE
 from .constants import CMD_OUTPUT_TOGGLE
 from .constants import CMD_RESET
 from .constants import CMD_STOP
+from .constants import CMD_TOGGLE_ADDRESS_DECODING
 from .constants import CMD_TOGGLE_LOGGING
 from .constants import CMD_TOGGLE_TIMESTAMPS
 from .constants import CTRL_H
@@ -34,6 +35,7 @@ from .key_config import RECOMPILE_UPLOAD_ALL_KEY
 from .key_config import RECOMPILE_UPLOAD_APP_KEY
 from .key_config import RECOMPILE_UPLOAD_KEY
 from .key_config import SKIP_MENU_KEY
+from .key_config import TOGGLE_ADDRESS_DECODING_KEY
 from .key_config import TOGGLE_LOG_KEY
 from .key_config import TOGGLE_OUTPUT_KEY
 from .key_config import TOGGLE_TIMESTAMPS_KEY
@@ -108,6 +110,8 @@ class ConsoleParser:
             ret = (TAG_CMD, CMD_TOGGLE_LOGGING)
         elif c in [TOGGLE_TIMESTAMPS_KEY, 'i', 'I']:  # Toggle printing timestamps
             ret = (TAG_CMD, CMD_TOGGLE_TIMESTAMPS)
+        elif c in [TOGGLE_ADDRESS_DECODING_KEY, 'd', 'D']:  # Toggle decoding of addresses
+            ret = (TAG_CMD, CMD_TOGGLE_ADDRESS_DECODING)
         elif c == CHIP_RESET_BOOTLOADER_KEY:
             # to fast trigger pause without press menu key
             ret = (TAG_CMD, CMD_ENTER_BOOT)
@@ -136,6 +140,7 @@ class ConsoleParser:
                {key_description(TOGGLE_OUTPUT_KEY):14} Toggle output display
                {key_description(TOGGLE_LOG_KEY):14} Toggle saving output into file
                {key_description(TOGGLE_TIMESTAMPS_KEY) + ' (or I)':14} Toggle printing timestamps
+               {key_description(TOGGLE_ADDRESS_DECODING_KEY) + ' (or D)':14} Toggle decoding of addresses
                {key_description(CHIP_RESET_BOOTLOADER_KEY):14} Reset target into bootloader via the DTR/RTS lines
                {key_description(EXIT_MENU_KEY) + ' (or X)':14} Exit program"""  # noqa: E501
 

--- a/esp_idf_monitor/base/constants.py
+++ b/esp_idf_monitor/base/constants.py
@@ -20,6 +20,7 @@ CMD_TOGGLE_LOGGING = 6
 CMD_ENTER_BOOT = 7
 CMD_TOGGLE_TIMESTAMPS = 8
 CMD_FLASH_ALL = 9
+CMD_TOGGLE_ADDRESS_DECODING = 10
 
 # Process exit code of a script that timed out waiting for 'expect' in the
 # non-interactive command mode, so that CI can tell it apart from a clean run.

--- a/esp_idf_monitor/base/key_config.py
+++ b/esp_idf_monitor/base/key_config.py
@@ -36,6 +36,7 @@ RECOMPILE_UPLOAD_ALL_KEY = key_to_hex(cfg.get('recompile_upload_all_key'), 'E')
 TOGGLE_OUTPUT_KEY = key_to_hex(cfg.get('toggle_output_key'), 'Y')
 TOGGLE_LOG_KEY = key_to_hex(cfg.get('toggle_log_key'), 'L')
 TOGGLE_TIMESTAMPS_KEY = key_to_hex(cfg.get('toggle_timestamp_key'), 'I')
+TOGGLE_ADDRESS_DECODING_KEY = key_to_hex(cfg.get('toggle_address_decoding_key'), 'D')
 CHIP_RESET_BOOTLOADER_KEY = key_to_hex(cfg.get('chip_reset_bootloader_key'), 'P')
 EXIT_MENU_KEY = key_to_hex(cfg.get('exit_menu_key'), 'X')
 try:
@@ -53,6 +54,7 @@ COMMAND_KEYS = [
     TOGGLE_OUTPUT_KEY,
     TOGGLE_LOG_KEY,
     TOGGLE_TIMESTAMPS_KEY,
+    TOGGLE_ADDRESS_DECODING_KEY,
     CHIP_RESET_BOOTLOADER_KEY,
     EXIT_MENU_KEY,
     SKIP_MENU_KEY,

--- a/esp_idf_monitor/base/logger.py
+++ b/esp_idf_monitor/base/logger.py
@@ -36,13 +36,21 @@ class Logger:
         self.log_file = None  # type: Optional[BinaryIO]
         self._output_enabled = True  # type: bool
         self._start_of_line = True  # type: bool
-        self.elf_file = elf_files[0] if elf_files else ''
+        self.elf_files = elf_files or []
+        self.elf_file = self.elf_files[0] if self.elf_files else ''
         self.console = console
         self.timestamps = timestamps
         self.timestamp_format = timestamp_format
-        self.pc_address_decoder = None  # always set; SerialHandler may call handlers when ELF exists but decoding off
+        self.toolchain_prefix = toolchain_prefix
+        self.rom_elf_file = rom_elf_file
+        self._address_decoding_enabled = enable_address_decoding  # type: bool
+        self._pc_address_decoder = None  # type: Optional[PcAddressDecoder]
         if enable_address_decoding:
-            self.pc_address_decoder = PcAddressDecoder(toolchain_prefix, elf_files, rom_elf_file)
+            self._pc_address_decoder = PcAddressDecoder(toolchain_prefix, elf_files, rom_elf_file)
+
+    @property
+    def pc_address_decoder(self) -> Optional[PcAddressDecoder]:
+        return self._pc_address_decoder if self._address_decoding_enabled else None
 
     @property
     def pc_address_buffer(self) -> bytes:
@@ -77,6 +85,20 @@ class Logger:
 
     def toggle_timestamps(self):  # type: () -> None
         self.timestamps = not self.timestamps
+
+    def toggle_address_decoding(self):  # type: () -> None
+        if not any(os.path.exists(f) for f in self.elf_files):
+            # No ELF also means SerialHandlerNoElf, which never calls the decoding
+            # handlers, so the flag would change nothing in either direction.
+            log.print('')
+            log.err('Address decoding is unavailable: no ELF file to decode against.')
+            return
+
+        self._address_decoding_enabled = not self._address_decoding_enabled
+        if self._address_decoding_enabled and self._pc_address_decoder is None:
+            self._pc_address_decoder = PcAddressDecoder(self.toolchain_prefix, self.elf_files, self.rom_elf_file)
+        log.print('')
+        log.note(f'Toggle address decoding: {self._address_decoding_enabled}')
 
     def start_logging(self):  # type: () -> None
         if not self._log_file:

--- a/esp_idf_monitor/base/serial_handler.py
+++ b/esp_idf_monitor/base/serial_handler.py
@@ -28,6 +28,7 @@ from .constants import CMD_MAKE
 from .constants import CMD_OUTPUT_TOGGLE
 from .constants import CMD_RESET
 from .constants import CMD_STOP
+from .constants import CMD_TOGGLE_ADDRESS_DECODING
 from .constants import CMD_TOGGLE_LOGGING
 from .constants import CMD_TOGGLE_TIMESTAMPS
 from .constants import CONSOLE_STATUS_QUERY
@@ -407,6 +408,8 @@ class SerialHandler:
             self.logger.toggle_logging()
         elif cmd == CMD_TOGGLE_TIMESTAMPS:
             self.logger.toggle_timestamps()
+        elif cmd == CMD_TOGGLE_ADDRESS_DECODING:
+            self.logger.toggle_address_decoding()
         elif cmd == CMD_ENTER_BOOT:
             log.note(
                 'Pause app (enter bootloader mode), press '

--- a/esp_idf_monitor/config.py
+++ b/esp_idf_monitor/config.py
@@ -22,6 +22,7 @@ VALID_OPTIONS = [
     'toggle_output_key',
     'toggle_log_key',
     'toggle_timestamp_key',
+    'toggle_address_decoding_key',
     'chip_reset_bootloader_key',
     'exit_menu_key',
     'skip_menu_key',

--- a/test/host_test/test_monitor.py
+++ b/test/host_test/test_monitor.py
@@ -20,6 +20,7 @@ from typing import Dict
 from typing import List
 from typing import Optional
 from typing import Tuple
+from unittest.mock import MagicMock
 from unittest.mock import patch
 
 import pytest
@@ -36,6 +37,7 @@ from esp_idf_monitor.base.constants import CMD_MAKE
 from esp_idf_monitor.base.constants import CMD_OUTPUT_TOGGLE
 from esp_idf_monitor.base.constants import CMD_RESET
 from esp_idf_monitor.base.constants import CMD_STOP
+from esp_idf_monitor.base.constants import CMD_TOGGLE_ADDRESS_DECODING
 from esp_idf_monitor.base.constants import CMD_TOGGLE_LOGGING
 from esp_idf_monitor.base.constants import CMD_TOGGLE_TIMESTAMPS
 from esp_idf_monitor.base.constants import EXIT_EXPECT_TIMEOUT
@@ -1203,6 +1205,88 @@ class TestFlashAllCommands:
         assert calls == [('flash', {})]
 
 
+class TestAddressDecodingToggle:
+    """Unit tests for toggling address decoding at runtime."""
+
+    class _DummyConsole:
+        pass
+
+    def _logger(self, elf_files, enable_address_decoding):
+        # type: (List[str], bool) -> Logger
+        return Logger(
+            elf_files=elf_files,
+            console=self._DummyConsole(),
+            timestamps=False,
+            timestamp_format='',
+            enable_address_decoding=enable_address_decoding,
+            toolchain_prefix='riscv32-esp-elf-',
+        )
+
+    def test_console_parser_toggle_address_decoding_key(self):
+        """Menu + Ctrl-D / D maps to CMD_TOGGLE_ADDRESS_DECODING."""
+        from esp_idf_monitor.base.key_config import MENU_KEY
+        from esp_idf_monitor.base.key_config import TOGGLE_ADDRESS_DECODING_KEY
+
+        for key in (TOGGLE_ADDRESS_DECODING_KEY, 'd', 'D'):
+            parser = ConsoleParser()
+            assert parser.parse(MENU_KEY) is None
+            assert parser.parse(key) == (TAG_CMD, CMD_TOGGLE_ADDRESS_DECODING)
+
+    def test_help_mentions_address_decoding(self):
+        assert 'Toggle decoding of addresses' in ConsoleParser().get_help_text()
+
+    def test_command_dispatch_calls_logger(self):
+        """CMD_TOGGLE_ADDRESS_DECODING reaches Logger.toggle_address_decoding()."""
+        from esp_idf_monitor.base.serial_handler import SerialHandler
+
+        # object.__new__ skips __init__; this command branch only reads .logger.
+        handler = object.__new__(SerialHandler)
+        handler.logger = MagicMock()
+        handler.handle_commands(CMD_TOGGLE_ADDRESS_DECODING, 'esp32', None, None, None)
+        handler.logger.toggle_address_decoding.assert_called_once_with()
+
+    def test_toggle_off_and_on_reuses_decoder(self, tmp_path):
+        """Turning decoding off hides the decoder; turning it back on reuses the instance."""
+        elf = tmp_path / 'example.elf'
+        elf.write_bytes(b'not an ELF')  # a truncated real ELF header makes elftools throw; only existence matters
+
+        logger = self._logger([str(elf)], enable_address_decoding=True)
+        decoder = logger.pc_address_decoder
+        assert decoder is not None
+
+        with patch.object(log, 'print'), patch.object(log, 'note'):
+            logger.toggle_address_decoding()
+            assert logger.pc_address_decoder is None
+
+            logger.toggle_address_decoding()
+            assert logger.pc_address_decoder is decoder
+
+    def test_toggle_on_builds_decoder_lazily(self, tmp_path):
+        """Starting with decoding disabled builds the decoder only once it is enabled."""
+        elf = tmp_path / 'example.elf'
+        elf.write_bytes(b'not an ELF')
+
+        logger = self._logger([str(elf)], enable_address_decoding=False)
+        assert logger.pc_address_decoder is None
+
+        with patch.object(log, 'print'), patch.object(log, 'note'):
+            logger.toggle_address_decoding()
+        assert logger.pc_address_decoder is not None
+
+    @pytest.mark.parametrize('elf_files', [[], ['/nonexistent/example.elf']])
+    @pytest.mark.parametrize('enabled', [True, False])
+    def test_toggle_without_elf_is_rejected(self, elf_files: List[str], enabled: bool):
+        """Without an ELF file there is nothing to decode against, in either direction."""
+        logger = self._logger(elf_files, enable_address_decoding=enabled)
+        before = logger.pc_address_decoder
+
+        with patch.object(log, 'print'), patch.object(log, 'err') as err:
+            logger.toggle_address_decoding()
+
+        assert logger.pc_address_decoder is before
+        assert err.call_count == 1
+
+
 class TestTagKeyEncoding:
     """Regression tests for encoding console key events for the serial port."""
 
@@ -1253,6 +1337,7 @@ class TestCommandReader:
             ('output', CMD_OUTPUT_TOGGLE),
             ('log', CMD_TOGGLE_LOGGING),
             ('timestamps', CMD_TOGGLE_TIMESTAMPS),
+            ('addresses', CMD_TOGGLE_ADDRESS_DECODING),
             ('bootloader', CMD_ENTER_BOOT),
         ],
     )


### PR DESCRIPTION
## Description

Address decoding could only be set at startup via `--disable-address-decoding`. Bind it to Ctrl+T Ctrl+D (or Ctrl+T D), configurable through the new `toggle_address_decoding_key` option, and expose it as the 'addresses' command in the non-interactive command mode.

## Testing

Tested locally.

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x] 🚨 This PR does not introduce breaking changes.
- [ ] All CI checks (GH Actions) pass.
- [ ] Documentation is updated as needed.
- [x] Tests are updated or added as necessary.
- [x] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.
